### PR TITLE
infra: Pin hugo-version in GitHub Actions workflow to 0.139.3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.139.3'
           extended: true
 
       - name: Build


### PR DESCRIPTION
Temporary workaround to handle unexpected 404s with the latest release, 0.139.5.

Link: https://github.com/Binary-Eater/binary-eater.github.io/actions/runs/12334251620/job/34424304310